### PR TITLE
Modify verb dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-util": "^2.2.14",
     "lodash": "^2.4.1",
     "through2": "^0.5.1",
-    "verb": "^0.2.6"
+    "verb": "0.x.x"
   },
   "devDependencies": {
     "event-stream": "^3.1.5",


### PR DESCRIPTION
_Verb_ dependency is hugely out-dated, and the latest version match will download a version of _verb_ which depends on _repo-templates_; a package no longer available at NPM. By modifying the semver specification for the _verb_ dependency we can guarantee that we still use any new minor version of the library, thus avoiding this kind of unmatched dependency issues.
